### PR TITLE
Migrate to Jekyll 3.8.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
-gem 'jekyll', '~> 3.7.0'
+gem 'jekyll', '~> 3.8.0'
 
 gem 'autoprefixer-rails', '~>  7.2.5'
 gem 'jekyll-feed', '~> 0.9.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,7 +39,7 @@ GEM
     http_parser.rb (0.6.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    jekyll (3.7.4)
+    jekyll (3.8.5)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
@@ -102,7 +102,7 @@ PLATFORMS
 DEPENDENCIES
   autoprefixer-rails (~> 7.2.5)
   html-proofer (~> 3.8.0)
-  jekyll (~> 3.7.0)
+  jekyll (~> 3.8.0)
   jekyll-feed (~> 0.9.2)
   jekyll-sitemap (~> 1.1.1)
   rake (~> 12.3.0)


### PR DESCRIPTION
Includes the following updates:
* [3.8.0](https://github.com/jekyll/jekyll/releases/tag/v3.8.0)
* [3.8.1](https://github.com/jekyll/jekyll/releases/tag/v3.8.1)
* [3.8.2](https://github.com/jekyll/jekyll/releases/tag/v3.8.2)
* [3.8.3](https://github.com/jekyll/jekyll/releases/tag/v3.8.3)
* [3.8.4](https://github.com/jekyll/jekyll/releases/tag/v3.8.4)
* [3.8.5](https://github.com/jekyll/jekyll/releases/tag/v3.8.5)