### PR TITLE
Void's _config.yml enables feeds for tags of blog posts

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -203,5 +203,4 @@ footer_links:
 # Feed Settings
 feed:
   path: /feed.xml
-  # TODO Ensure tag feed works properly
-  tag:  /feed/tag/%s.atom.xml
+  tags: true


### PR DESCRIPTION
I want there to be flexibility for the tags related to blog posts to be available for subscription if the user wants.